### PR TITLE
Update to check if new GLUT is present on host

### DIFF
--- a/depends/check-pspgl.sh
+++ b/depends/check-pspgl.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
  ls $(psp-config --psp-prefix)/lib/libGL.a \
     $(psp-config --psp-prefix)/lib/libGLU.a \
+    $(psp-config --psp-prefix)/lib/libglut.a \
     $(psp-config --psp-prefix)/include/GL \
     $(psp-config --psp-prefix)/include/GLES
 


### PR DESCRIPTION
GLUT support has been added few months ago to pspGL, so this checks too if it's present or not on the host machine.